### PR TITLE
Update beta key URL

### DIFF
--- a/rootfs/opt/makemkv/bin/makemkv-update-beta-key
+++ b/rootfs/opt/makemkv/bin/makemkv-update-beta-key
@@ -26,7 +26,7 @@ fi
 
 # Download the web page.
 TMPFILE="$(mktemp)"
-wget --timeout 10 -qO "$TMPFILE" 'http://www.makemkv.com/forum2/viewtopic.php?f=5&t=1053'
+wget --timeout 10 -qO "$TMPFILE" 'https://www.makemkv.com/forum/viewtopic.php?f=5&t=1053'
 if [ "$?" -ne 0 ]; then
     echo "ERROR: Failed to fetch download key."
     exit 1


### PR DESCRIPTION
Old redirects to this new one so just use this new one, especially since HTTPS.