### PR TITLE
Added TAKE_OUTPUT_OWNERSHIP environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ of this parameter has the format `<VARIABLE_NAME>=<VALUE>`.
 |`AUTO_DISC_RIPPER_BD_MODE`| Rip mode of Blu-ray discs.  `mkv` is the default mode, where a set of MKV files are produced.  When set to `backup`, a copy of the (decrypted) file system is created instead. **NOTE**: This applies to Blu-ray discs only.  For DVD discs, MKV files are always produced. | `mkv` |
 |`AUTO_DISC_RIPPER_FORCE_UNIQUE_OUTPUT_DIR`| When set to `0`, files are written to `/output/DISC_LABEL/`, where `DISC_LABEL` is the label/name of the disc.  If this directory exists, then files are written to `/output/DISC_LABEL-XXXXXX`, where `XXXXXX` are random readable characters.  When set to `1`, the `/output/DISC_LABEL-XXXXXX` pattern is always used. | `0` |
 |`AUTO_DISC_RIPPER_NO_GUI_PROGRESS`| When set to `1`, progress of discs ripped by the automatic disc ripper is not shown in the MakeMKV GUI. | `0` |
+|`TAKE_OUTPUT_OWNERSHIP`| When set to `1`, owner and group of `/output` (including all its files and subfolders) are automatically set during container startup to `USER_ID` and `GROUP_ID` respectively. | `1` |
 
 ### Data Volumes
 

--- a/appdefs.xml
+++ b/appdefs.xml
@@ -622,6 +622,18 @@ section for more details.
         <mask>false</mask>
       </unraid_template>
     </environment_variable>
+    <environment_variable>
+      <name>TAKE_OUTPUT_OWNERSHIP</name>
+      <description>When set to `1`, owner and group of `/output` (including all its files and subfolders) are automatically set during container startup to `USER_ID` and `GROUP_ID` respectively.</description>
+      <default>1</default>
+      <unraid_template>
+        <title>Take Output Ownership</title>
+        <description>When set to `1`, owner and group of /output (including all its files and subfolders) are automatically set during container startup to USER_ID and GROUP_ID respectively.</description>
+        <display>always</display>
+        <required>false</required>
+        <mask>false</mask>
+      </unraid_template>
+    </environment_variable>
     </environment_variables>
     <!-- Volumes -->
     <volumes>

--- a/rootfs/etc/cont-init.d/90-makemkv.sh
+++ b/rootfs/etc/cont-init.d/90-makemkv.sh
@@ -71,13 +71,15 @@ esac
 find /config -mindepth 1 -exec chown $USER_ID:$GROUP_ID {} \;
 
 # Take ownership of the output directory.
-if ! chown $USER_ID:$GROUP_ID /output; then
-    # Failed to take ownership of /output.  This could happen when,
-    # for example, the folder is mapped to a network share.
-    # Continue if we have write permission, else fail.
-    if s6-setuidgid $USER_ID:$GROUP_ID [ ! -w /output ]; then
-        log "ERROR: Failed to take ownership and no write permission on /output."
-        exit 1
+if [ "${TAKE_OUTPUT_OWNERSHIP:-1}" -eq 1 ]; then
+    if ! chown $USER_ID:$GROUP_ID /output; then
+        # Failed to take ownership of /output.  This could happen when,
+        # for example, the folder is mapped to a network share.
+        # Continue if we have write permission, else fail.
+        if s6-setuidgid $USER_ID:$GROUP_ID [ ! -w /output ]; then
+            log "ERROR: Failed to take ownership and no write permission on /output."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
 Added `TAKE_OUTPUT_OWNERSHIP` environment variable to control whether `/output` is `chown`'d during startup.

Fixes #115 