### PR TITLE
Handling trailing dashes in 54-check-optical-drive.sh

### DIFF
--- a/rootfs/etc/cont-init.d/54-check-optical-drive.sh
+++ b/rootfs/etc/cont-init.d/54-check-optical-drive.sh
@@ -13,8 +13,8 @@ if [ ! -f "$DRIVES_INFO" ]; then
 fi
 
 while read -r DRV; do
-    SR_DEV="$(echo "$DRV" | rev | cut -d' ' -f2 | rev)"
-    SG_DEV="$(echo "$DRV" | rev | cut -d' ' -f1 | rev)"
+    SR_DEV="$(echo "$DRV" | grep -oE '/dev/sr[0-9]+')"
+    SG_DEV="$(echo "$DRV" | grep -oE '/dev/sg[0-9]+')"
 
     if [ -e "$SG_DEV" ] && [ -e "$SR_DEV" ]; then
         FOUND_USABLE_DRIVE=1


### PR DESCRIPTION
Fixes device enumeration where a trailing dash is undermining the cut/rev.

For example, on my host, `lsscsi -g -k | grep -w "cd/dvd" | tr -s ' '` is producing the output:
```
[1:0:0:0] cd/dvd HL-DT-ST BD-RE WH14NS40 1.05 /dev/sr0 - 
```

When `rev | cut -d' ' -f2 | rev` is used, it's locking onto the dash, not the device path.

This patch explicitly uses the device path.