### PR TITLE
hooks: Fix incorrect $STATUS check in disc_rip_terminated example

### DIFF
--- a/rootfs/defaults/hooks/disc_rip_terminated.sh.example
+++ b/rootfs/defaults/hooks/disc_rip_terminated.sh.example
@@ -16,7 +16,7 @@ OUTPUT_DIR="$3"
 STATUS="$4"
 
 case "$STATUS" in
-    0)
+    "SUCCESS")
         echo "The automatic disc ripper successfully ripped disc '$DISC_LABEL' (drive $DRV_ID)."
         ;;
     *)


### PR DESCRIPTION
I was setting up hooks and got a bit tripped up by this example, turns out it expects the string "SUCCESS" not the number 0