### PR TITLE
Use device node names rather than kernel names to check optical drives

### DIFF
--- a/rootfs/etc/cont-init.d/54-check-optical-drive.sh
+++ b/rootfs/etc/cont-init.d/54-check-optical-drive.sh
@@ -64,11 +64,11 @@ echo 0 > "$USABLE_DRIVES_FOUND"
 
 lsscsi | grep -w "cd/dvd" | awk '{print $1}' | tr -d '[]' | while read -r DRV_ID
 do
-    DRV="$(lsscsi -b -k -g "$DRV_ID" | tr -s ' ' | xargs)"
+    DRV="$(lsscsi -g "$DRV_ID" | tr -s ' ' | xargs)"
     DRV_NAME="$(lsscsi -c "$DRV_ID" | grep Vendor: | sed -r 's/(Vendor:|Model:|Rev:)//g' | tr -s ' ' | xargs)"
 
-    SR_DEV="$(echo "$DRV" | awk '{print $2}')"
-    SG_DEV="$(echo "$DRV" | awk '{print $3}')"
+    SR_DEV="$(echo "$DRV" | awk '{print $(NF-1)}')"
+    SG_DEV="$(echo "$DRV" | awk '{print $(NF)}')"
 
     #
     # MakeMKV requires the sg device to work. The sr device is optional, but


### PR DESCRIPTION
This change allows devices to be symlinked in host for improved device naming stability

When my computer power cycles, I find that the sg device's name/path tends to change between `/dev/sg0`, `/dev/sg1` and so forth. I've created a udev rule as follows:

```
# Stable symlink for the block device
SUBSYSTEM=="block", KERNEL=="sr*", ATTRS{serial}=="myserialno", ATTRS{idVendor}=="08e4", ATTRS{idProduct}=="017a", SYMLINK+="bluray/sr"

# Stable symlink for the sg device
SUBSYSTEM=="scsi_generic", ATTRS{serial}=="myserialno", ATTRS{idVendor}=="08e4", ATTRS{idProduct}=="017a", SYMLINK+="bluray/sg"
```

Thus I can provide the symlinks as the devices in the compose definition:
```yaml
    devices:
      - "/dev/bluray/sr:/dev/bluray_sr"
      - "/dev/bluray/sg:/dev/bluray_sg"
```

However the existing `54-check-optical-drive.sh` is incompatible with these symlinks due to its use of kernel names. This fix will allow the drives to be detected even when symlinks are used.